### PR TITLE
AtCoder の新しい順位表に対応する

### DIFF
--- a/atcoder_tl.rb
+++ b/atcoder_tl.rb
@@ -59,12 +59,9 @@ def update_all(config)
   all_and_agc_colors.each do |color|
     $logger.info "[#{color.name}] Started All Update"
 
-    atcoder_usernames = []
-    for user in atcoder_users_all
-      if color.rating_lb <= user.rating && user.rating <= color.rating_ub
-        atcoder_usernames.append user.username
-      end
-    end
+    atcoder_usernames = atcoder_users_all.select do |user|
+      user.rating.between?(color.rating_lb, color.rating_ub)
+    end.map(&:username)
 
     log_ids('atcoder_usernames', atcoder_usernames, color)
 

--- a/atcoder_tl.rb
+++ b/atcoder_tl.rb
@@ -55,10 +55,17 @@ def update_all(config)
   twitter_client = get_twitter_client(config['twitter'])
   twitter_client.update('全リストの更新を開始します。') unless is_dry_run
 
+  atcoder_users_all = RankingPage.users()
   all_and_agc_colors.each do |color|
     $logger.info "[#{color.name}] Started All Update"
 
-    atcoder_usernames = RankingPage.usernames(color)
+    atcoder_usernames = []
+    for user in atcoder_users_all
+      if color.rating_lb <= user.rating && user.rating <= color.rating_ub
+        atcoder_usernames.append user.username
+      end
+    end
+
     log_ids('atcoder_usernames', atcoder_usernames, color)
 
     users = UserPage.users(atcoder_usernames, color)

--- a/atcoder_tl/ranking_page.rb
+++ b/atcoder_tl/ranking_page.rb
@@ -31,17 +31,15 @@ module RankingPage
     end
 
     def parse(html)
-      user = Struct.new(:username, :rank, :rating)
+      user = Struct.new(:username, :rating)
       doc = Nokogiri::HTML.parse(html, nil, 'utf-8')
-      entries = doc.css('tbody').css('tr')
+      entries = doc.css('tbody/tr')
       result = []
       for entry in entries
-        rank = entry.children[1].text.to_i
-        username = entry.children[3].css('span')[0].text
-        country_image_url = entry.children[3].css('img')[0]['src'] # the image representing the country always comes first. Crowns, if present, follow.
-        rating = entry.children[7].text.to_i
+        _rank, username, _birth_year, rating, _max_rating, _participants, _win = entry.css('td')
+        country_image_url = username.css('img')[0]['src'] # The image representing the country always comes first. Crowns, if present, follow.
         if country_image_url == '//img.atcoder.jp/assets/flag/JP.png'
-          result.append user.new(username, rank, rating)
+          result.append user.new(username.css('span')[0].text, rating.text.to_i)
         end
       end
       is_last_page = entries.size < 100

--- a/atcoder_tl/ranking_page.rb
+++ b/atcoder_tl/ranking_page.rb
@@ -23,10 +23,6 @@ module RankingPage
       users
     end
 
-    def last_page?(usernames_on_page)
-      usernames_on_page.size < 100
-    end
-
     def url(page)
       options = {
         'page' => page,
@@ -37,9 +33,9 @@ module RankingPage
     def parse(html)
       user = Struct.new(:username, :rank, :rating)
       doc = Nokogiri::HTML.parse(html, nil, 'utf-8')
-      entries = doc.css('tr') # TODO find better css selector
+      entries = doc.css('tbody').css('tr')
       result = []
-      for entry in entries[1..] # Need to skip the first row, because it contains explanation of the columns
+      for entry in entries
         rank = entry.children[1].text.to_i
         username = entry.children[3].css('span')[0].text
         country_image_url = entry.children[3].css('img')[0]['src'] # the image representing the country always comes first. Crowns, if present, follow.
@@ -48,7 +44,7 @@ module RankingPage
           result.append user.new(username, rank, rating)
         end
       end
-      is_last_page = entries.size < 101
+      is_last_page = entries.size < 100
       [result, is_last_page]
     end
   end

--- a/atcoder_tl/ranking_page.rb
+++ b/atcoder_tl/ranking_page.rb
@@ -4,41 +4,52 @@ module RankingPage
   class << self
     include Util
 
-    def usernames(color)
-      usernames = []
+    # Returns a list consisting of struct(username, rank, rating)
+    def users()
+      users = []
       page = 1
       while true
-        url = url(color.rating_lb, color.rating_ub, page)
-        $logger.info "[#{color.name}] Downloading #{url}"
+        url = url(page)
+        $logger.info "Downloading #{url}"
 
         html = download(url)
-        usernames_on_page = parse(html)
-        usernames.concat usernames_on_page
+        users_on_page, is_last_page = parse(html)
+        users.concat users_on_page
 
-        break if last_page?(usernames_on_page)
+        break if is_last_page
         page += 1
       end
 
-      usernames
+      users
     end
 
     def last_page?(usernames_on_page)
       usernames_on_page.size < 100
     end
 
-    def url(rating_lower_bound, rating_upper_bound, page)
+    def url(page)
       options = {
-        'f.Country' => 'JP',
-        'f.RatingLowerBound' => rating_lower_bound,
-        'f.RatingUpperBound' => rating_upper_bound,
         'page' => page,
       }
       "https://atcoder.jp/ranking?" + options.map{ |h| h.join('=') }.join('&')
     end
 
     def parse(html)
+      user = Struct.new(:username, :rank, :rating)
       doc = Nokogiri::HTML.parse(html, nil, 'utf-8')
-      doc.css('#main-container a.username').map(&:text)
+      entries = doc.css('tr') # TODO find better css selector
+      result = []
+      for entry in entries[1..] # Need to skip the first row, because it contains explanation of the columns
+        rank = entry.children[1].text.to_i
+        username = entry.children[3].css('span')[0].text
+        country_image_url = entry.children[3].css('img')[0]['src'] # the image representing the country always comes first. Crowns, if present, follow.
+        rating = entry.children[7].text.to_i
+        if country_image_url == '//img.atcoder.jp/assets/flag/JP.png'
+          result.append user.new(username, rank, rating)
+        end
+      end
+      is_last_page = entries.size < 101
+      [result, is_last_page]
     end
   end
 end


### PR DESCRIPTION
以下の重大な設計変更をします:

- レート範囲を絞ってユーザリストを取得するのをやめ、一度に全てのユーザを取得する。新しいランキングページにはレート範囲や国などで絞り込み判定する機能が失われており、今後追加されるかどうかも不明なため、この変更をしました。

## 動作確認
Twitter リストが手元にないので動くかどうかの確認はできませんでしたが、Twitter リスト関連の操作をする直前に、username に期待されるもの (特定のレート範囲のユーザ名の配列) が入っていそうなことは確認しました。

## 懸念点
使っている CSS selector があまり良いものとは言えないので、良さそうなものなどがあればお聞きしたいです

